### PR TITLE
Sort features when receiving input as hash

### DIFF
--- a/lib/lightgbm/booster.rb
+++ b/lib/lightgbm/booster.rb
@@ -141,6 +141,10 @@ module LightGBM
       input =
         if daru?(input)
           input.map_rows(&:to_a)
+        elsif input.is_a?(Hash) # sort feature.values to match the order of model.feature_name
+          sorted_feature_values(input)
+        elsif input.is_a?(Array) && input.first.is_a?(Hash) # on multiple elems, if 1st is hash, assume they all are
+          input.map(&method(:sorted_feature_values))
         else
           input.to_a
         end
@@ -239,6 +243,11 @@ module LightGBM
     # read_int64 not available on JRuby
     def read_int64(ptr)
       ptr.read_array_of_int64(1).first
+    end
+
+    def sorted_feature_values(input_hash)
+      @cached_feature_names ||= feature_name
+      input_hash.transform_keys(&:to_s).fetch_values(*@cached_feature_names)
     end
 
     include Utils

--- a/test/booster_test.rb
+++ b/test/booster_test.rb
@@ -30,6 +30,22 @@ class BoosterTest < Minitest::Test
     assert_includes error.message, "Unknown importance type"
   end
 
+  def test_predict_with_hash_builds_sorted_input
+    pred = booster.predict({x0: 3.7, x1: 1.2, x2: 7.2, x3: 9.0})
+    assert_in_delta 0.9823112229173586, pred
+
+    pred = booster.predict({"x3" => 9.0, "x2" => 7.2, "x1" => 1.2, "x0" => 3.7})
+    assert_in_delta 0.9823112229173586, pred
+
+    pred = booster.predict(
+      [
+        {"x3" => 9.0, "x2" => 7.2, "x1" => 1.2, "x0" => 3.7},
+        {"x3" => 0.0, "x2" => 7.9, "x1" => 0.5, "x0" => 7.5},
+      ]
+    )
+    assert_elements_in_delta [0.9823112229173586, 0.9583143724610858], pred.first(2)
+  end
+
   def test_model_to_string
     assert booster.model_to_string
   end


### PR DESCRIPTION
Given the popular usage of hashes in Ruby, I think this would be a nice quality of life addition to the Booster#predict API.