### PR TITLE
Add support for different prediction types

### DIFF
--- a/lib/lightgbm.rb
+++ b/lib/lightgbm.rb
@@ -3,6 +3,7 @@ require "ffi"
 
 # modules
 require_relative "lightgbm/utils"
+require_relative "lightgbm/macros"
 require_relative "lightgbm/booster"
 require_relative "lightgbm/dataset"
 require_relative "lightgbm/version"

--- a/lib/lightgbm/ffi.rb
+++ b/lib/lightgbm/ffi.rb
@@ -38,6 +38,7 @@ module LightGBM
     attach_function :LGBM_BoosterLoadModelFromString, %i[string pointer pointer], :int
     attach_function :LGBM_BoosterFree, %i[pointer], :int
     attach_function :LGBM_BoosterAddValidData, %i[pointer pointer], :int
+    attach_function :LGBM_BoosterCalcNumPredict, %i[pointer int int int int pointer], :int
     attach_function :LGBM_BoosterGetNumClasses, %i[pointer pointer], :int
     attach_function :LGBM_BoosterUpdateOneIter, %i[pointer pointer], :int
     attach_function :LGBM_BoosterGetCurrentIteration, %i[pointer pointer], :int

--- a/lib/lightgbm/macros.rb
+++ b/lib/lightgbm/macros.rb
@@ -1,0 +1,7 @@
+module LightGBM
+  # Macro definition of prediction type in C API of LightGBM
+  C_API_PREDICT_NORMAL = 0
+  C_API_PREDICT_RAW_SCORE = 1
+  C_API_PREDICT_LEAF_INDEX = 2
+  C_API_PREDICT_CONTRIB = 3
+end

--- a/test/booster_test.rb
+++ b/test/booster_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 
 class BoosterTest < Minitest::Test
-  def test_model_file
+  def test_predict
     x_test = [[3.7, 1.2, 7.2, 9.0], [7.5, 0.5, 7.9, 0.0]]
     booster = LightGBM::Booster.new(model_file: "test/support/model.txt")
     y_pred = booster.predict(x_test)
@@ -21,21 +21,6 @@ class BoosterTest < Minitest::Test
     booster.model_from_string(File.read("test/support/model.txt"))
     y_pred = booster.predict(x_test)
     assert_elements_in_delta [0.9823112229173586, 0.9583143724610858], y_pred.first(2)
-  end
-
-  def test_feature_importance
-    assert_equal [280, 285, 335, 148], booster.feature_importance
-  end
-
-  def test_feature_name
-    assert_equal ["x0", "x1", "x2", "x3"], booster.feature_name
-  end
-
-  def test_feature_importance_bad_importance_type
-    error = assert_raises(LightGBM::Error) do
-      booster.feature_importance(importance_type: "bad")
-    end
-    assert_includes error.message, "Unknown importance type"
   end
 
   def test_predict_hash
@@ -86,6 +71,68 @@ class BoosterTest < Minitest::Test
     assert_raises(KeyError) do
       booster.predict(Rover::DataFrame.new([{"x0" => 3.7}]))
     end
+  end
+
+  def test_predict_type_leaf_index
+    x_test = [[3.7, 1.2, 7.2, 9.0], [7.5, 0.5, 7.9, 0.0]]
+    leaf_indexes = booster.predict(x_test, predict_type: LightGBM::C_API_PREDICT_LEAF_INDEX)
+    assert_equal 200, leaf_indexes.count
+    assert_equal 9.0, leaf_indexes.first
+    assert_equal 7.0, leaf_indexes.last
+
+    x_test = [3.7, 1.2, 7.2, 9.0]
+    leaf_indexes = booster.predict(x_test, predict_type: LightGBM::C_API_PREDICT_LEAF_INDEX)
+    assert_equal 100, leaf_indexes.count
+    assert_equal 9.0, leaf_indexes.first
+    assert_equal 10.0, leaf_indexes.last
+  end
+
+  def test_predict_type_contrib
+    x_test = [[3.7, 1.2, 7.2, 9.0], [7.5, 0.5, 7.9, 0.0]]
+    results = booster.predict(x_test, predict_type: LightGBM::C_API_PREDICT_CONTRIB)
+    assert_equal 10, results.count
+
+    # split results on num_features + 1
+    predictions = results.each_slice(5).to_a
+    shap_values_1 = predictions.first[0..-2]
+    ypred_1 = predictions.first[-1]
+    assert_elements_in_delta [
+      -0.0733949225678886, -0.24289592050101766, 0.24183795683166504, 0.063430775771174
+    ], shap_values_1
+    assert_in_delta (0.9933333333834246), ypred_1
+
+    shap_values_2 = predictions.last[0..-2]
+    ypred_2 = predictions.last[-1]
+    assert_elements_in_delta [
+      0.1094902954684793, -0.2810485083947154, 0.26691627597706397, -0.13037702397316747
+    ], shap_values_2
+    assert_in_delta (0.9933333333834246), ypred_2
+
+    # single row
+    x_test = [3.7, 1.2, 7.2, 9.0]
+    results = booster.predict(x_test, predict_type: LightGBM::C_API_PREDICT_CONTRIB)
+    assert_equal 5, results.count
+    shap_values = results[0..-2]
+    ypred = results[-1]
+    assert_elements_in_delta [
+      -0.0733949225678886, -0.24289592050101766, 0.24183795683166504, 0.063430775771174
+    ], shap_values
+    assert_in_delta (0.9933333333834246), ypred
+  end
+
+  def test_feature_importance
+    assert_equal [280, 285, 335, 148], booster.feature_importance
+  end
+
+  def test_feature_name
+    assert_equal ["x0", "x1", "x2", "x3"], booster.feature_name
+  end
+
+  def test_feature_importance_bad_importance_type
+    error = assert_raises(LightGBM::Error) do
+      booster.feature_importance(importance_type: "bad")
+    end
+    assert_includes error.message, "Unknown importance type"
   end
 
   def test_model_to_string


### PR DESCRIPTION
Adds support for different prediction types.

C API: https://lightgbm.readthedocs.io/en/stable/C-API.html#c.LGBM_BoosterPredictForMat

Python API: https://lightgbm.readthedocs.io/en/stable/pythonapi/lightgbm.Booster.html#lightgbm.Booster.predict

