### PR TITLE
Calculate pandas categorical hash once.

### DIFF
--- a/lib/lightgbm/booster.rb
+++ b/lib/lightgbm/booster.rb
@@ -269,7 +269,8 @@ module LightGBM
         last_line = model_str[idx..].strip
       end
       if last_line.start_with?(pandas_key)
-        JSON.parse(last_line[pandas_key.length..])
+        pandas_categorical = JSON.parse(last_line[pandas_key.length..])
+        pandas_categorical.map { |cats| cats.each_with_index.to_h }
       end
     end
 

--- a/lib/lightgbm/inner_predictor.rb
+++ b/lib/lightgbm/inner_predictor.rb
@@ -140,7 +140,7 @@ module LightGBM
 
     def apply_pandas_categorical(data, categorical_feature, pandas_categorical)
       (categorical_feature || []).each_with_index do |cf, i|
-        cat_codes = pandas_categorical[i].map.with_index.to_h
+        cat_codes = pandas_categorical[i]
         data.each do |r|
           cat = r[cf]
           unless cat.nil?


### PR DESCRIPTION
Build the pandas_categorical index hash when loading the model, instead of doing it on every `predict()`.

Doing it on `predict()` significantly slows down the prediction, especially for larger categorical feature lists and wastes CPU cycles since this can be just calculated once.  

After change:

Number of categorical features: 3
Biggest category length: 11945
Predict for 10.000 times: 0.3876569999847561 seconds

Before change:

Number of categorical features: 3
Biggest category length: 11945
Predict for 10.000 times: 15.50964699999895 seconds

Benchmark code:
```ruby
    time = Benchmark.measure do
      x_test = [[3.7, 1.2,  "cat9", "100.8.6448"], [7.5, 0.5,  "cat0", "100.0.4262",]]
      booster = LightGBM::Booster.new(model_file: "test/support/categorical.txt")
      pandas_categorical = booster.instance_variable_get(:@pandas_categorical)
      puts "Number of categorical features: #{pandas_categorical.length}"
      puts "Biggest category length: #{pandas_categorical.max_by { |category| category.length }.length}"
      10000.times do
        y_pred = booster.predict(x_test)
      end
    end
    puts "Benchmark cached: #{time.real} seconds"
```

Added a large categorical feature in the test model with almost 12k entries.